### PR TITLE
fixed access control

### DIFF
--- a/MetalKitPlus/MTKPComputer.swift
+++ b/MetalKitPlus/MTKPComputer.swift
@@ -23,7 +23,7 @@ import Metal
     - note: Should be used subclassed and conform to `MTKFunctionExecutor`
  */
 public struct MTKPComputer : MTKPCommandQueue {
-    var assets:MTKPAssets
+    public var assets:MTKPAssets
     
     public init(assets:MTKPAssets) {
         self.assets = assets

--- a/MetalKitPlus/MTKPShaderIO.swift
+++ b/MetalKitPlus/MTKPShaderIO.swift
@@ -35,7 +35,7 @@ public protocol MTKPBufferLoader {
 public protocol MTKPIOProvider : MTKPTextureLoader, MTKPBufferLoader {}
 
 open class MTKPShaderIO : MTKPDeviceUser {
-    private(set) var textureLoader:MTKTextureLoader? = nil
+    public private(set) var textureLoader:MTKTextureLoader? = nil
     
     public init() {
         guard let device = self.device else {


### PR DESCRIPTION
textureLoader in MTKPShaderIO and assets in MTKPComputer are now public, thus visible outside the framework.