### PR TITLE
added shared memory loader in ioprovider

### DIFF
--- a/MetalKitPlus/MTKPIOProvider.swift
+++ b/MetalKitPlus/MTKPIOProvider.swift
@@ -35,7 +35,15 @@ public protocol MTKPBufferLoader {
 }
 
 /**
+ *
+ */
+
+public protocol MTKPThreadgroupMemoryLoader {
+    func fetchThreadgroupMemory() -> Int?
+}
+
+/**
  * 
  */
 
-public protocol MTKPIOProvider : MTKPTextureLoader, MTKPBufferLoader {}
+public protocol MTKPIOProvider : MTKPTextureLoader, MTKPBufferLoader, MTKPThreadgroupMemoryLoader {}


### PR DESCRIPTION
It would be helpful if the IOProvider could store the size of the shared memory. The provider now conforms to following protocol:
`public protocol MTKPThreadgroupMemoryLoader {`
`    func fetchThreadgroupMemory() -> Int?`
`}`